### PR TITLE
chore: upgrade react-docgen-typescript

### DIFF
--- a/packages/react-docgen-typescript-loader/package.json
+++ b/packages/react-docgen-typescript-loader/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "ajv": "^6.5.0",
-    "react-docgen-typescript": "^1.5.0"
+    "react-docgen-typescript": "^1.6.0"
   },
   "peerDependencies": {
     "typescript": "*"


### PR DESCRIPTION
Upgrade react-docgen-typescript to 1.6.0 with new fixes https://github.com/styleguidist/react-docgen-typescript/releases/tag/v1.6.0
```
parse can be called with multiple source file paths (thanks to @marionebl PR #91)
upgraded typescript version and fixed parsing comment problem (thanks to @kbukum PR #97)
```