### PR TITLE
feat: Reuse typescript program in between parses

### DIFF
--- a/src/loader.spec.ts
+++ b/src/loader.spec.ts
@@ -8,13 +8,18 @@ import loader from "./loader";
 const mockLoaderContextAsyncCallback = jest.fn();
 const mockLoaderContextCacheable = jest.fn();
 const mockLoaderContextResourcePath = jest.fn();
+const mockLoaderContextContext = jest.fn();
 
 beforeEach(() => {
   mockLoaderContextAsyncCallback.mockReset();
   mockLoaderContextCacheable.mockReset();
   mockLoaderContextResourcePath.mockReset();
+  mockLoaderContextContext.mockReset();
   mockLoaderContextResourcePath.mockImplementation(() =>
     path.resolve(__dirname, "./__fixtures__/components/Simple.tsx"),
+  );
+  mockLoaderContextContext.mockImplementation(() =>
+    path.resolve(__dirname, "./__fixtures__/"),
   );
 });
 
@@ -31,9 +36,10 @@ function executeLoaderWithBoundContext() {
       async: mockLoaderContextAsyncCallback,
       cacheable: mockLoaderContextCacheable,
       resourcePath: mockLoaderContextResourcePath(),
+      context: mockLoaderContextContext(),
     } as Pick<
       webpack.loader.LoaderContext,
-      "async" | "cacheable" | "resourcePath"
+      "async" | "cacheable" | "resourcePath" | "context"
     >) as webpack.loader.LoaderContext,
     "// Original Source Code",
   );

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,7 @@
 import webpack from "webpack";
+import * as ts from "typescript";
+import path from "path";
+import fs from "fs";
 // TODO: Import from "react-docgen-typescript" directly when
 // https://github.com/styleguidist/react-docgen-typescript/pull/104 is hopefully
 // merged in. Will be considering to make a peer dependency as that point.
@@ -13,6 +16,14 @@ import LoaderOptions from "./LoaderOptions";
 import validateOptions from "./validateOptions";
 import generateDocgenCodeBlock from "./generateDocgenCodeBlock";
 import { getOptions } from "loader-utils";
+
+export interface TSFile {
+  text?: string;
+  version: number;
+}
+
+let languageService: ts.LanguageService | null = null;
+const files: Map<string, TSFile> = new Map<string, TSFile>();
 
 export default function loader(
   this: webpack.loader.LoaderContext,
@@ -72,13 +83,50 @@ function processResource(
   // Configure parser using settings provided to loader.
   // See: node_modules/react-docgen-typescript/lib/parser.d.ts
   let parser: FileParser = withDefaultConfig(parserOptions);
+
+  let compilerOptions: ts.CompilerOptions = {
+    allowJs: true,
+  };
+  let tsConfigFile: ts.ParsedCommandLine | null = null;
+
   if (options.tsconfigPath) {
     parser = withCustomConfig(options.tsconfigPath, parserOptions);
+
+    tsConfigFile = getTSConfigFile(options.tsconfigPath!);
+    compilerOptions = tsConfigFile.options;
+
+    const filesToLoad = tsConfigFile.fileNames;
+    loadFiles(filesToLoad);
   } else if (options.compilerOptions) {
     parser = withCompilerOptions(options.compilerOptions, parserOptions);
+    compilerOptions = options.compilerOptions;
   }
 
-  const componentDocs = parser.parse(context.resourcePath);
+  if (!tsConfigFile) {
+    const basePath = path.dirname(context.context);
+    tsConfigFile = getDefaultTSConfigFile(basePath);
+
+    const filesToLoad = tsConfigFile.fileNames;
+    loadFiles(filesToLoad);
+  }
+
+  const componentDocs = parser.parseWithProgramProvider(
+    context.resourcePath,
+    () => {
+      if (languageService) {
+        return languageService.getProgram()!;
+      }
+
+      const servicesHost = createServiceHost(compilerOptions, files);
+
+      languageService = ts.createLanguageService(
+        servicesHost,
+        ts.createDocumentRegistry(),
+      );
+
+      return languageService!.getProgram()!;
+    },
+  );
 
   // Return amended source code if there is docgen information available.
   if (componentDocs.length) {
@@ -93,4 +141,68 @@ function processResource(
 
   // Return unchanged source code if no docgen information was available.
   return source;
+}
+
+function getTSConfigFile(tsconfigPath: string): ts.ParsedCommandLine {
+  const basePath = path.dirname(tsconfigPath);
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  return ts.parseJsonConfigFileContent(
+    configFile!.config,
+    ts.sys,
+    basePath,
+    {},
+    tsconfigPath,
+  );
+}
+
+function getDefaultTSConfigFile(basePath: string): ts.ParsedCommandLine {
+  return ts.parseJsonConfigFileContent({}, ts.sys, basePath, {});
+}
+
+function loadFiles(filesToLoad: string[]): void {
+  let normalizedFilePath: string;
+  filesToLoad.forEach(filePath => {
+    normalizedFilePath = path.normalize(filePath);
+    files.set(normalizedFilePath, {
+      text: fs.readFileSync(normalizedFilePath, "utf-8"),
+      version: 0,
+    });
+  });
+}
+
+function createServiceHost(
+  compilerOptions: ts.CompilerOptions,
+  files: Map<string, TSFile>,
+): ts.LanguageServiceHost {
+  return {
+    getScriptFileNames: () => {
+      return [...Array.from(files.keys())];
+    },
+    getScriptVersion: fileName => {
+      const file = files.get(fileName);
+      return (file && file.version.toString()) || "";
+    },
+    getScriptSnapshot: fileName => {
+      if (!fs.existsSync(fileName)) {
+        return undefined;
+      }
+
+      let file = files.get(fileName);
+
+      if (file === undefined) {
+        const text = fs.readFileSync(fileName).toString();
+
+        file = { version: 0, text };
+        files.set(fileName, file);
+      }
+
+      return ts.ScriptSnapshot.fromString(file!.text!);
+    },
+    getCurrentDirectory: () => process.cwd(),
+    getCompilationSettings: () => compilerOptions,
+    getDefaultLibFileName: options => ts.getDefaultLibFilePath(options),
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+  };
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -176,7 +176,7 @@ function createServiceHost(
 ): ts.LanguageServiceHost {
   return {
     getScriptFileNames: () => {
-      return [...Array.from(files.keys())];
+      return [...files.keys()];
     },
     getScriptVersion: fileName => {
       const file = files.get(fileName);


### PR DESCRIPTION
Because we are not reusing the same Typescript instance while parsing ts files there are this issue https://github.com/styleguidist/react-docgen-typescript/issues/112 and this issue https://github.com/strothj/react-docgen-typescript-loader/issues/37.

So here I've created a code, which reuse the same program in between parses in the same way as in `ts-loader` it's done (https://github.com/TypeStrong/ts-loader/blob/master/src/servicesHost.ts)