### PR TITLE
fix: hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .vscode/
+.idea/
 .rpt2_cache/
 dist/
 *error.log

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -160,13 +160,22 @@ function getDefaultTSConfigFile(basePath: string): ts.ParsedCommandLine {
 }
 
 function loadFiles(filesToLoad: string[]): void {
-  let normalizedFilePath: string;
   filesToLoad.forEach(filePath => {
-    normalizedFilePath = path.normalize(filePath);
-    files.set(normalizedFilePath, {
-      text: fs.readFileSync(normalizedFilePath, "utf-8"),
-      version: 0,
-    });
+    const normalizedFilePath = path.normalize(filePath);
+    const file = files.get(normalizedFilePath);
+    const text = fs.readFileSync(normalizedFilePath, "utf-8");
+
+    if (!file) {
+      files.set(normalizedFilePath, {
+        text,
+        version: 0,
+      });
+    } else if (file.text !== text) {
+      files.set(normalizedFilePath, {
+        text,
+        version: file.version + 1,
+      });
+    }
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/strothj/react-docgen-typescript-loader/issues/43

Currently docgen isn't updated during HMR. Fixed it by upping updated file version so TS would know to update it in cache.

One drawback though: if you're importing type from another file hot reload would not work when you change file with export, but will work when you update file which imports the type.