### PR TITLE
Make the name of the "type" property of the generated docgen structure configurable.

### DIFF
--- a/src/LoaderOptions.ts
+++ b/src/LoaderOptions.ts
@@ -54,4 +54,11 @@ export default interface LoaderOptions {
    * @see https://github.com/styleguidist/react-docgen-typescript#parseroptions
    * */
   shouldExtractLiteralValuesFromEnum?: boolean;
+
+  /**
+   * Specifiy the name of the property for docgen info prop type.
+   *
+   * @default "type"
+   */
+  typePropName?: string;
 }

--- a/src/generateDocgenCodeBlock.spec.ts
+++ b/src/generateDocgenCodeBlock.spec.ts
@@ -39,6 +39,7 @@ function getGeneratorOptions(parserOptions: ParserOptions = {}) {
       componentDocs: parse(filePath, parserOptions),
       docgenCollectionName: null,
       setDisplayName: true,
+      typePropName: "type",
     } as GeneratorOptions;
   };
 }

--- a/src/generateDocgenCodeBlock.ts
+++ b/src/generateDocgenCodeBlock.ts
@@ -8,6 +8,7 @@ export interface GeneratorOptions {
   componentDocs: ComponentDoc[];
   docgenCollectionName: string | null;
   setDisplayName: boolean;
+  typePropName: string;
 }
 
 export default function generateDocgenCodeBlock(
@@ -38,7 +39,7 @@ export default function generateDocgenCodeBlock(
   const codeBlocks = options.componentDocs.map(d =>
     wrapInTryStatement([
       options.setDisplayName ? setDisplayName(d) : null,
-      setComponentDocGen(d),
+      setComponentDocGen(d, options),
       options.docgenCollectionName != null
         ? insertDocgenIntoGlobalCollection(
             d,
@@ -101,8 +102,12 @@ function setDisplayName(d: ComponentDoc): ts.Statement {
  * ```
  *
  * @param d Component doc.
+ * @param options Generator options.
  */
-function setComponentDocGen(d: ComponentDoc): ts.Statement {
+function setComponentDocGen(
+  d: ComponentDoc,
+  options: GeneratorOptions,
+): ts.Statement {
   return insertTsIgnoreBeforeStatement(
     ts.createStatement(
       ts.createBinary(
@@ -128,7 +133,7 @@ function setComponentDocGen(d: ComponentDoc): ts.Statement {
             ts.createLiteral("props"),
             ts.createObjectLiteral(
               Object.entries(d.props).map(([propName, prop]) =>
-                createPropDefinition(propName, prop),
+                createPropDefinition(propName, prop, options),
               ),
             ),
           ),
@@ -152,8 +157,13 @@ function setComponentDocGen(d: ComponentDoc): ts.Statement {
  *
  * @param propName Prop name
  * @param prop Prop definition from `ComponentDoc.props`
+ * @param options Generator options.
  */
-function createPropDefinition(propName: string, prop: PropItem) {
+function createPropDefinition(
+  propName: string,
+  prop: PropItem,
+  options: GeneratorOptions,
+) {
   /**
    * Set default prop value.
    *
@@ -264,7 +274,7 @@ function createPropDefinition(propName: string, prop: PropItem) {
     }
 
     return ts.createPropertyAssignment(
-      ts.createLiteral("type"),
+      ts.createLiteral(options.typePropName),
       ts.createObjectLiteral(objectFields),
     );
   };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -130,6 +130,8 @@ function processResource(
     },
   );
 
+  options.typePropName = options.typePropName || "type";
+
   // Return amended source code if there is docgen information available.
   if (componentDocs.length) {
     return generateDocgenCodeBlock({
@@ -138,6 +140,7 @@ function processResource(
       componentDocs,
       docgenCollectionName: options.docgenCollectionName,
       setDisplayName: options.setDisplayName,
+      typePropName: options.typePropName,
     });
   }
 

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -48,6 +48,10 @@ const schema = {
     shouldExtractLiteralValuesFromEnum: {
       type: "boolean",
     },
+
+    typePropName: {
+      type: "string",
+    },
   },
 };
 


### PR DESCRIPTION
As stated in the title, this PR add an option to configure the name of the "type" property of the generated docgen.

The idea is to be able to generate the same docgen structure that is generated by [react-docgen](https://github.com/reactjs/react-docgen#result-data-structure) for a TS component.

My goal is to have a way to identify which type system the docgen info have been generated from and apply a specific series of transformation based on that type system.

"type" -> PropTypes
"tsType-> TypeScript
"flowType" -> Flow

Thank you,

Patrick