### PR TITLE
do not mutate webpack context (options)

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -58,7 +58,7 @@ function processResource(
   // deterministic.
   context.cacheable(true);
 
-  const options: LoaderOptions = getOptions(context) || {};
+  const options: LoaderOptions = Object.assign({}, getOptions(context));
   validateOptions(options);
 
   options.docgenCollectionName =


### PR DESCRIPTION
It's not safe to mutate options according to this: https://github.com/webpack/loader-utils#getoptions

I run in strange error because of this when this loader is used on project with code-splitting and only index file has correct options passed `react-docgen-typescript-loader`.