### PR TITLE
Reduce synchronous file IO

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -25,7 +25,7 @@ export interface TSFile {
 let languageService: ts.LanguageService | null = null;
 const files: Map<string, TSFile> = new Map<string, TSFile>();
 
-export default function loader(
+export default async function loader(
   this: webpack.loader.LoaderContext,
   source: string,
 ) {
@@ -36,7 +36,7 @@ export default function loader(
   const callback = this.async();
 
   try {
-    const newSource = processResource(this, source);
+    const newSource = await processResource(this, source);
 
     if (!callback) return newSource;
     callback(null, newSource);
@@ -50,10 +50,10 @@ export default function loader(
   }
 }
 
-function processResource(
+async function processResource(
   context: webpack.loader.LoaderContext,
   source: string,
-): string {
+): Promise<string> {
   // Mark the loader as being cacheable since the result should be
   // deterministic.
   context.cacheable(true);
@@ -100,7 +100,7 @@ function processResource(
     compilerOptions = tsConfigFile.options;
 
     const filesToLoad = tsConfigFile.fileNames;
-    loadFiles(filesToLoad);
+    await loadFiles(filesToLoad);
   } else if (options.compilerOptions) {
     parser = withCompilerOptions(options.compilerOptions, parserOptions);
     compilerOptions = options.compilerOptions;
@@ -111,7 +111,7 @@ function processResource(
     tsConfigFile = getDefaultTSConfigFile(basePath);
 
     const filesToLoad = tsConfigFile.fileNames;
-    loadFiles(filesToLoad);
+    await loadFiles(filesToLoad);
   }
 
   const componentDocs = parser.parseWithProgramProvider(
@@ -166,24 +166,35 @@ function getDefaultTSConfigFile(basePath: string): ts.ParsedCommandLine {
   return ts.parseJsonConfigFileContent({}, ts.sys, basePath, {});
 }
 
-function loadFiles(filesToLoad: string[]): void {
-  filesToLoad.forEach(filePath => {
+function loadFiles(filesToLoad: string[]): Promise<void[]> {
+  return Promise.all(filesToLoad.map(filePath => {
     const normalizedFilePath = path.normalize(filePath);
-    const file = files.get(normalizedFilePath);
-    const text = fs.readFileSync(normalizedFilePath, "utf-8");
 
-    if (!file) {
-      files.set(normalizedFilePath, {
-        text,
-        version: 0,
+    return new Promise<void>((resolve) => {
+      fs.readFile(normalizedFilePath, "utf-8", (err, text) => {
+        if (err) {
+          resolve()
+          return
+        }
+
+        const file = files.get(normalizedFilePath);
+
+        if (!file) {
+          files.set(normalizedFilePath, {
+            text,
+            version: 0,
+          });
+        } else if (file.text !== text) {
+          files.set(normalizedFilePath, {
+            text,
+            version: file.version + 1
+          })
+        }
+
+        resolve()
       });
-    } else if (file.text !== text) {
-      files.set(normalizedFilePath, {
-        text,
-        version: file.version + 1,
-      });
-    }
-  });
+    })
+  }));
 }
 
 function createServiceHost(
@@ -199,13 +210,13 @@ function createServiceHost(
       return (file && file.version.toString()) || "";
     },
     getScriptSnapshot: fileName => {
-      if (!fs.existsSync(fileName)) {
-        return undefined;
-      }
-
       let file = files.get(fileName);
 
       if (file === undefined) {
+        if (!fs.existsSync(fileName)) {
+          return undefined;
+        }
+
         const text = fs.readFileSync(fileName).toString();
 
         file = { version: 0, text };


### PR DESCRIPTION
This change switches the initial loading of TypeScript into memory from synchronous to asynchronous, and avoids using `fs.existsSync` in the Service Host if we already have the file in memory. 

For most setups this probably won't make much of a difference, but my project runs in Docker Desktop for Mac, which has a long standing issue with slow, CPU-intensive file IO in mounted folders, so it is necessary to keep build times reasonable. Moving to async for most of the filesystem operations keeps Webpack from pausing each time this loader is invoked.
